### PR TITLE
Remove images with broken links

### DIFF
--- a/appunti-tolc-psi/biologia/dna-rna.md
+++ b/appunti-tolc-psi/biologia/dna-rna.md
@@ -10,7 +10,6 @@ Singolo filamento con zucchero ribosio. Può essere messaggero (mRNA), di
 trasferimento (tRNA) o ribosomiale (rRNA). Partecipa alla traduzione delle
 informazioni del DNA in proteine.
 
-![DNA](https://upload.wikimedia.org/wikipedia/commons/5/55/DNA_simple2.svg)
 
 ## Esercizio
 > **Domanda**: Dove si trova il DNA nella cellula eucariote?

--- a/appunti-tolc-psi/biologia/la-cellula.md
+++ b/appunti-tolc-psi/biologia/la-cellula.md
@@ -15,7 +15,6 @@ Il nucleo custodisce il DNA, i mitocondri producono energia tramite la
 respirazione cellulare e il reticolo endoplasmatico coordina la sintesi di
 lipidi e proteine. L'apparato di Golgi modifica e smista le molecole prodotte.
 
-![Cellula animale](https://upload.wikimedia.org/wikipedia/commons/0/0a/Animal_cell_structure_en.svg)
 
 ## Esercizio
 > **Domanda**: Qual è l'organulo responsabile della produzione di energia?

--- a/appunti-tolc-psi/biologia/molecole-biologiche.md
+++ b/appunti-tolc-psi/biologia/molecole-biologiche.md
@@ -15,7 +15,6 @@ Unità base delle proteine, formate da un gruppo amminico e uno carbossilico
 legati a un carbonio centrale. Dal legame tra amminoacidi derivano i peptidi e
 le proteine complesse.
 
-![Struttura di un amminoacido](https://upload.wikimedia.org/wikipedia/commons/3/33/Generic_amino_acid_structure.svg)
 
 ## Nucleotidi
 Costituenti di DNA e RNA. Ogni nucleotide è composto da zucchero pentoso,


### PR DESCRIPTION
## Summary
- remove broken image links from Biology notes

## Testing
- `grep -R '!\[' -n appunti-tolc-psi`

------
https://chatgpt.com/codex/tasks/task_e_684089593cb4832da1522bfc3eb1f663